### PR TITLE
move dotenv require to server/index.js

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const cookieParser = require('cookie-parser');
-require('dotenv').config();
 
 const app = express();
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,5 @@
+require('dotenv').config();
+
 const port = process.env.PORT;
-require('./app').listen(
-  process.env.PORT,
-  () => console.log(`app is live on http://localhost:${port}`),
-);
+
+require('./app').listen(process.env.PORT, () => console.log(`app is live on http://localhost:${port}`));


### PR DESCRIPTION
moved dotenv require to server/index.js because process.env wouldn't read secrets from .env file when it's was located in app.js